### PR TITLE
player_health.res: Added drawcolor to PlayerStatusHealthImageBG2

### DIFF
--- a/#customizations/addons/health-ammo-style_classic/player_health.res
+++ b/#customizations/addons/health-ammo-style_classic/player_health.res
@@ -62,7 +62,7 @@
 		"enabled"		"1"
 		"image"			"replay/thumbnails/hp_bg_under"
 		"scaleImage"		"1"
-		
+		"drawcolor"		"52 50 52"
 		"pin_to_sibling"		"PlayerStatusHealthImageBG3"
 		"pin_corner_to_sibling"	"PIN_TOPLEFT"
 		"pin_to_sibling_corner"	"PIN_TOPLEFT"


### PR DESCRIPTION
Hi, I've been using this HUD for a couple years now and it really is my favorite. Randomly looked to see if there was an update for that damn MvM Credit Box being off in the corner and found this repo had been updated recently, so I wanted to suggest a quick change.

In the 'health-ammo-style_classic' mode, the background on the health meter when your health is being lowered is a blinding 255 255 255 white and just didn't look right to me. With a dark grey that's still distinct from the black background, the amount left at a glance is a bit more clear. 

I'm not really great with HUDs so if this isn't the way to go, then feel free to edit or close. 